### PR TITLE
Quiet unexpected IRQ trap errors in dmesg

### DIFF
--- a/emu/setup_emu
+++ b/emu/setup_emu
@@ -108,3 +108,11 @@ for pin in $pins_high; do
    echo out > /sys/class/gpio/gpio$pin/direction
    echo 1 > /sys/class/gpio/gpio$pin/value
 done
+
+# hide dmesg warnings about unhandled IRQs
+# (IRQs are being handled by the PRUs directly, not Linux)
+if [ "$KERNEL_VER" -ge "4" ]; then
+   gpiomon gpiochip0 8 9 10 11 12 13 > /dev/null 2>&1 &
+   sleep 0.5
+   kill $!
+fi


### PR DESCRIPTION
4.x+ Linux kernels are monitoring all gpios for IRQs. This leads
to dmesg noise of the following type when emulating a drive:

```
[  965.142762] unexpected IRQ trap at vector 6f
[  965.147067] irq 109, desc: a0327774, depth: 1, count: 0, unhandled: 0
[  965.147078] ->handle_irq():  9f2bd4b9, handle_bad_irq+0x0/0x280
[  965.147087] ->irq_data.chip(): 7d9505d2, 0xcf8fd740
[  965.147094] ->action(): 00000000
[  965.147100]    IRQ_NOPROBE set
```

These are spurious since all interrupts are being handled by PRU0.

By using `gpiomon` to watch, then clear, interrupts on the contested
GPIO lines on the ARM, we can remove the dmesg noise. The `sleep 0.5`
is necessary to give `gpiomon` enough time to setup libgpiod before
tearing it down.