### PR TITLE
mfm_decoder.h - Add ext2emu support for Microbee_WD1002_05

### DIFF
--- a/mfm/inc/mfm_decoder.h
+++ b/mfm/inc/mfm_decoder.h
@@ -1,6 +1,8 @@
 #ifndef MFM_DECODER_H_
 #define MFM_DECODER_H_
 //
+// 11/06/26 DV Add ext2emu support for Microbee_WD1002_05
+//     reused Intel_iSBC_214_512B - changed start_sector 1 
 // 06/04/25 DJG Changed trk_Xebec_* to use 5 ID mark patterns to match image
 //    mindset_st225_base.emu. 
 //    https://bitsavers.org/pdf/xebec/Xebec_S1410/104478B_S1410A_Feb84.pdf
@@ -3189,6 +3191,16 @@ DEF_EXTERN CONTROLLER mfm_controller_info[]
          0, ARRAYSIZE(mfm_all_init), CINFO_CHS,
          5, 2, 0, 0, CHECK_CRC, CHECK_CRC,
          0, 1, trk_ISBC214_1024b, 1024, 9, 0, 5209,
+         0, 0,
+         {0xffff,0x1021,16,0},{0xffffffff,0x140a0445,32,6}, CONT_MODEL,
+         0, 0, 0, 0
+      },
+      // same as Intel_iSBC_214_512B with start_sector 1
+      {"Microbee_WD1002_05",      128, 10000000,      0,
+         4, ARRAYSIZE(mfm_all_poly), 4, ARRAYSIZE(mfm_all_poly), 
+         0, ARRAYSIZE(mfm_all_init), CINFO_CHS,
+         5, 2, 0, 0, CHECK_CRC, CHECK_CRC,
+         0, 1, trk_ISBC214_512B, 512, 17, 1, 5209,
          0, 0,
          {0xffff,0x1021,16,0},{0xffffffff,0x140a0445,32,6}, CONT_MODEL,
          0, 0, 0, 0

--- a/mfm/inc/mfm_decoder.h
+++ b/mfm/inc/mfm_decoder.h
@@ -1,7 +1,7 @@
 #ifndef MFM_DECODER_H_
 #define MFM_DECODER_H_
 //
-// 11/06/26 DV Add ext2emu support for Microbee_WD1002_05
+// 11/06/26 DV Add ext2emu support for Microbee_WD1002_05_Teac_10M
 //     reused Intel_iSBC_214_512B - changed start_sector 1 
 // 06/04/25 DJG Changed trk_Xebec_* to use 5 ID mark patterns to match image
 //    mindset_st225_base.emu. 
@@ -3195,15 +3195,40 @@ DEF_EXTERN CONTROLLER mfm_controller_info[]
          {0xffff,0x1021,16,0},{0xffffffff,0x140a0445,32,6}, CONT_MODEL,
          0, 0, 0, 0
       },
-      // same as Intel_iSBC_214_512B with start_sector 1
-      {"Microbee_WD1002_05",      128, 10000000,      0,
-         4, ARRAYSIZE(mfm_all_poly), 4, ARRAYSIZE(mfm_all_poly), 
-         0, ARRAYSIZE(mfm_all_init), CINFO_CHS,
-         5, 2, 0, 0, CHECK_CRC, CHECK_CRC,
-         0, 1, trk_ISBC214_512B, 512, 17, 1, 5209,
-         0, 0,
-         {0xffff,0x1021,16,0},{0xffffffff,0x140a0445,32,6}, CONT_MODEL,
-         0, 0, 0, 0
+      // Microbee 10M (1224 tracks) 
+      //	Miniscribe 3012, Miniscribe 3212, Mitsubishi MR521 (2 heads x 612 cyls)
+      //	TEAC SD510 (4 heads x 306 cyls)
+      {
+	 "Microbee_1244_10M", 128, 10000000, 0,
+	 4, ARRAYSIZE(mfm_all_poly), 4, ARRAYSIZE(mfm_all_poly),
+	 0, ARRAYSIZE(mfm_all_init), CINFO_CHS,
+	 5, 2, 0, 0, CHECK_CRC, CHECK_CRC,
+	 0, 1, trk_ISBC214_512B, 512, 17, 1, 1224,
+	 0, 0,
+	 {0xffff, 0x1021, 16, 0}, {0xffffffff, 0x140a0445, 32, 6}, CONT_MODEL,
+	 0, 0, 0, 0
+      },
+      // Microbee 20.8M (2460 tracks) TEAC SD520 (20.91M, 4 heads × 615 cyls)
+      {
+	 "Microbee_2460_20M", 128, 10000000, 0,
+	 4, ARRAYSIZE(mfm_all_poly), 4, ARRAYSIZE(mfm_all_poly),
+	 0, ARRAYSIZE(mfm_all_init), CINFO_CHS,
+	 5, 2, 0, 0, CHECK_CRC, CHECK_CRC,
+	 0, 1, trk_ISBC214_512B, 512, 17, 1, 2460,
+	 0, 0,
+	 {0xffff, 0x1021, 16, 0}, {0xffffffff, 0x140a0445, 32, 6}, CONT_MODEL,
+	 0, 0, 0, 0
+      },	
+      // Microbee 20M (2488 tracks) Mitsubishi MR522 (20.8MB, 4 heads × 612 cyls)
+      { 
+	 "Microbee_2448_20M", 128, 10000000, 0,
+	 4, ARRAYSIZE(mfm_all_poly), 4, ARRAYSIZE(mfm_all_poly),
+	 0, ARRAYSIZE(mfm_all_init), CINFO_CHS,
+	 5, 2, 0, 0, CHECK_CRC, CHECK_CRC,
+	 0, 1, trk_ISBC214_512B, 512, 17, 1, 2448,
+	 0, 0,
+	 {0xffff, 0x1021, 16, 0}, {0xffffffff, 0x140a0445, 32, 6}, CONT_MODEL,
+	 0, 0, 0, 0
       },
       // TODO: Analyize currently can't separate this from Intel_iSBC_214_512B
       // since only different for heads >= 8


### PR DESCRIPTION
Added ext2emu support for Microbee_WD1002_05 (WD1002-05 controller on "Microbee Hard Disk Unit")
Used Intel_iSBC_214_512B with a single change: start_sector=1 